### PR TITLE
fix: Correct logging functionality for file and live view

### DIFF
--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -338,7 +338,7 @@ fn logging_thread_main(receiver: Receiver<Option<LogEntry>>, pipe_handle: isize)
         let mut file: Option<File> = None;
         if let Ok(appdata) = std::env::var("LOCALAPPDATA") {
             let mut log_dir = PathBuf::from(appdata);
-            log_dir.push("cs2_monitor");
+            log_dir.push("cs2_creator");
             log_dir.push("logs");
             if fs::create_dir_all(&log_dir).is_ok() {
                 let log_path = log_dir.join(format!("log_{}.txt", unsafe { GetCurrentProcessId() }));

--- a/loader/src/app/state.rs
+++ b/loader/src/app/state.rs
@@ -104,6 +104,7 @@ pub struct LogEntry {
     pub level: LogLevel,
     pub process_id: u32,
     pub thread_id: u32,
+    pub suspicion_score: usize,
     #[serde(flatten)]
     pub event: LogEvent,
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
This commit addresses two issues that caused logging to fail:

1.  The client DLL was writing logs to the incorrect directory (`cs2_monitor/logs` instead of `cs2_creator/logs`). The path has been corrected in `client/src/lib.rs`.

2.  The live viewer was empty because of a data structure mismatch. The client was sending a `LogEntry` with a `suspicion_score` field, but the loader GUI was not expecting it, causing deserialization to fail. The `LogEntry` struct in `loader/src/app/state.rs` has been updated to include this field, synchronizing the structures and fixing the live view.