### PR TITLE
Fix logging, UI, and add auto-injection feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3092,7 +3092,9 @@ checksum = "b7f4053bd8efd870677b67f018147024c268c1b570459483c73a2c527b98e279"
 name = "shared"
 version = "0.1.0"
 dependencies = [
+ "chrono",
  "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/client/src/code_monitor.rs
+++ b/client/src/code_monitor.rs
@@ -1,6 +1,5 @@
-use crate::config::LogLevel;
+use shared::logging::{LogLevel, LogEvent};
 use crate::log_event;
-use crate::logging::LogEvent;
 use windows_sys::Win32::Foundation::CloseHandle;
 use windows_sys::Win32::System::Diagnostics::Debug::ReadProcessMemory;
 use windows_sys::Win32::System::Memory::{

--- a/client/src/config.rs
+++ b/client/src/config.rs
@@ -4,36 +4,9 @@ use once_cell::sync::Lazy;
 use shared::MonitorConfig;
 use std::sync::{atomic::{AtomicBool, Ordering}, RwLock};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, serde::Serialize, serde::Deserialize)]
-pub enum LogLevel {
-    Fatal = 0,
-    Error = 1,
-    Success = 2,
-    Warn = 3,
-    Info = 4,
-    Debug = 5,
-    Trace = 6,
-}
-
-impl LogLevel {
-    pub fn from_env() -> Self {
-        match std::env::var("MONITOR_LOG_LEVEL").as_deref() {
-            Ok("FATAL") => LogLevel::Fatal,
-            Ok("ERROR") => LogLevel::Error,
-            Ok("SUCCESS") => LogLevel::Success,
-            Ok("WARN") => LogLevel::Warn,
-            Ok("INFO") => LogLevel::Info,
-            Ok("DEBUG") => LogLevel::Debug,
-            Ok("TRACE") => LogLevel::Trace,
-            _ => LogLevel::Info, // Default
-        }
-    }
-}
-
 pub struct Features {
     pub features: RwLock<MonitorConfig>,
     pub termination_allowed: AtomicBool,
-    pub log_level: LogLevel,
     pub stack_trace_on_error: bool,
     pub stack_trace_frame_limit: usize,
 }
@@ -44,15 +17,23 @@ impl Features {
     }
 }
 
-pub static CONFIG: Lazy<Features> = Lazy::new(|| Features {
-    features: RwLock::new(MonitorConfig::default()),
-    termination_allowed: AtomicBool::new(false),
-    log_level: LogLevel::from_env(),
-    stack_trace_on_error: std::env::var("MONITOR_STACK_TRACE_ON_ERROR")
+pub static CONFIG: Lazy<Features> = Lazy::new(|| {
+    let mut config = MonitorConfig::default();
+    let stack_trace_on_error = std::env::var("MONITOR_STACK_TRACE_ON_ERROR")
         .map(|s| s == "1" || s.eq_ignore_ascii_case("true"))
-        .unwrap_or(true),
-    stack_trace_frame_limit: std::env::var("MONITOR_STACK_TRACE_FRAME_LIMIT")
+        .unwrap_or(true);
+    let stack_trace_frame_limit = std::env::var("MONITOR_STACK_TRACE_FRAME_LIMIT")
         .ok()
         .and_then(|s| s.parse().ok())
-        .unwrap_or(16),
+        .unwrap_or(16);
+
+    config.stack_trace_on_error = stack_trace_on_error;
+    config.stack_trace_frame_limit = stack_trace_frame_limit;
+
+    Features {
+        features: RwLock::new(config),
+        termination_allowed: AtomicBool::new(false),
+        stack_trace_on_error,
+        stack_trace_frame_limit,
+    }
 });

--- a/client/src/hardware_bp.rs
+++ b/client/src/hardware_bp.rs
@@ -1,6 +1,5 @@
-use crate::config::LogLevel;
+use shared::logging::{LogLevel, LogEvent};
 use crate::log_event;
-use crate::logging::LogEvent;
 use serde_json::json;
 use windows_sys::Win32::System::Diagnostics::Debug::{CONTEXT, GetThreadContext};
 use windows_sys::Win32::System::Threading::{GetCurrentThread};

--- a/client/src/hooks/cpprest_hook.rs
+++ b/client/src/hooks/cpprest_hook.rs
@@ -1,6 +1,5 @@
-use crate::config::LogLevel;
+use shared::logging::{LogLevel, LogEvent};
 use crate::log_event;
-use crate::logging::LogEvent;
 use crate::scanner;
 use lazy_static::lazy_static;
 use retour::static_detour;

--- a/client/src/hooks/winapi_hooks.rs
+++ b/client/src/hooks/winapi_hooks.rs
@@ -1,5 +1,6 @@
-use crate::config::{LogLevel, CONFIG};
-use crate::logging::{capture_stack_trace, LogEvent};
+use shared::logging::{LogLevel, LogEvent};
+use crate::config::CONFIG;
+use crate::logging::capture_stack_trace;
 use crate::{log_event, SUSPICION_SCORE};
 use crate::ReentrancyGuard;
 use once_cell::sync::Lazy;

--- a/client/src/iat_monitor.rs
+++ b/client/src/iat_monitor.rs
@@ -1,6 +1,5 @@
-use crate::config::LogLevel;
+use shared::logging::{LogLevel, LogEvent};
 use crate::log_event;
-use crate::logging::LogEvent;
 use windows_sys::Win32::System::Diagnostics::ToolHelp::{
     CreateToolhelp32Snapshot, Module32FirstW, Module32NextW, MODULEENTRY32W, TH32CS_SNAPMODULE,
     TH32CS_SNAPMODULE32,

--- a/client/src/lib.rs
+++ b/client/src/lib.rs
@@ -11,10 +11,11 @@ mod logging;
 mod scanner;
 mod string_dumper;
 mod vmp_dumper;
-use crate::config::{LogLevel, CONFIG};
+use crate::config::CONFIG;
 use crate::hooks::{cpprest_hook, winapi_hooks};
-use crate::logging::{LogEntry, LogEvent, SectionInfo};
+use crate::logging::create_log_entry;
 use crossbeam_channel::{bounded, Receiver, Sender};
+use shared::logging::{LogEntry, LogEvent, LogLevel, SectionInfo};
 use once_cell::sync::OnceCell;
 use shared::{Command, MonitorConfig};
 use std::cell::Cell;
@@ -65,9 +66,8 @@ impl Drop for ReentrancyGuard {
 }
 
 pub fn log_event(level: LogLevel, event: LogEvent) {
-    if level > CONFIG.log_level { return; }
     if let Some(sender) = LOG_SENDER.get() {
-        let entry = LogEntry::new(level, event);
+        let entry = create_log_entry(level, event);
         let _ = sender.try_send(Some(entry));
     }
 }

--- a/client/src/logging.rs
+++ b/client/src/logging.rs
@@ -1,8 +1,9 @@
 #![allow(dead_code, unused_variables)]
-use crate::config::{LogLevel, CONFIG};
+use crate::config::CONFIG;
 use crate::SUSPICION_SCORE;
-use chrono::{DateTime, Utc};
+use chrono::Utc;
 use serde::{Deserialize, Serialize};
+use shared::logging::{LogEntry, LogEvent, LogLevel};
 use std::ffi::c_void;
 use windows_sys::Win32::System::Diagnostics::Debug::RtlCaptureStackBackTrace;
 use windows_sys::Win32::System::Threading::{GetCurrentProcessId, GetCurrentThreadId};
@@ -25,152 +26,47 @@ pub fn capture_stack_trace(max_frames: usize) -> Vec<String> {
         .collect()
 }
 
-/// Represents a single log entry in a structured, serializable format.
-#[derive(Serialize, Debug)]
-pub struct LogEntry {
-    #[serde(with = "chrono::serde::ts_seconds")]
-    pub timestamp: DateTime<Utc>,
-    pub level: LogLevel,
-    pub process_id: u32,
-    pub thread_id: u32,
-    pub suspicion_score: usize,
-    #[serde(flatten)]
-    pub event: LogEvent,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub stack_trace: Option<Vec<String>>,
-}
+/// Creates a new LogEntry for a given event, automatically capturing
+/// the timestamp, process ID, and thread ID. The stack trace is captured
+/// conditionally based on the global configuration and the event's log level,
+/// unless a stack trace is already provided with the event itself.
+pub fn create_log_entry(level: LogLevel, mut event: LogEvent) -> LogEntry {
+    // Check if the event itself comes with a stack trace.
+    // We take it from the event, so it's not duplicated in the final JSON.
+    let event_stack_trace = match &mut event {
+        LogEvent::ApiHook { stack_trace, .. } => stack_trace.take(),
+        LogEvent::AntiDebugCheck { stack_trace, .. } => stack_trace.take(),
+        _ => None,
+    };
 
-impl LogEntry {
-    /// Creates a new LogEntry for a given event, automatically capturing
-    /// the timestamp, process ID, and thread ID. The stack trace is captured
-    /// conditionally based on the global configuration and the event's log level,
-    /// unless a stack trace is already provided with the event itself.
-    pub fn new(level: LogLevel, mut event: LogEvent) -> Self {
-        // Check if the event itself comes with a stack trace.
-        // We take it from the event, so it's not duplicated in the final JSON.
-        let event_stack_trace = match &mut event {
-            LogEvent::ApiHook { stack_trace, .. } => stack_trace.take(),
-            LogEvent::AntiDebugCheck { stack_trace, .. } => stack_trace.take(),
-            _ => None,
-        };
-
-        let final_stack_trace = if event_stack_trace.is_some() {
-            event_stack_trace
+    let final_stack_trace = if event_stack_trace.is_some() {
+        event_stack_trace
+    } else {
+        // Fallback to the original logic if no trace is provided in the event.
+        let should_capture_stack = if CONFIG.stack_trace_on_error {
+            // For Fatal and Error, we always want a trace if possible.
+            level == LogLevel::Error || level == LogLevel::Fatal
         } else {
-            // Fallback to the original logic if no trace is provided in the event.
-            let should_capture_stack = if CONFIG.stack_trace_on_error {
-                // For Fatal and Error, we always want a trace if possible.
-                level == LogLevel::Error || level == LogLevel::Fatal
-            } else {
-                true // Capture if the setting is disabled
-            };
-
-            if should_capture_stack {
-                Some(capture_stack_trace(CONFIG.stack_trace_frame_limit))
-            } else {
-                None
-            }
+            true // Capture if the setting is disabled
         };
 
-        Self {
-            timestamp: Utc::now(),
-            level,
-            process_id: unsafe { GetCurrentProcessId() },
-            thread_id: unsafe { GetCurrentThreadId() },
-            suspicion_score: SUSPICION_SCORE.load(std::sync::atomic::Ordering::Relaxed),
-            event,
-            stack_trace: final_stack_trace,
+        if should_capture_stack {
+            Some(capture_stack_trace(CONFIG.stack_trace_frame_limit))
+        } else {
+            None
         }
+    };
+
+    LogEntry {
+        timestamp: Utc::now(),
+        level,
+        process_id: unsafe { GetCurrentProcessId() },
+        thread_id: unsafe { GetCurrentThreadId() },
+        suspicion_score: SUSPICION_SCORE.load(std::sync::atomic::Ordering::Relaxed),
+        event,
+        stack_trace: final_stack_trace,
     }
 }
-
-/// Enumerates the different types of events that can be logged.
-#[derive(Serialize, Debug, Clone)]
-#[serde(tag = "event_type", content = "details")]
-pub enum LogEvent {
-    Initialization {
-        status: String,
-    },
-    Shutdown {
-        status: String,
-    },
-    ApiHook {
-        function_name: String,
-        parameters: serde_json::Value,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        stack_trace: Option<Vec<String>>,
-    },
-    AntiDebugCheck {
-        function_name: String,
-        parameters: serde_json::Value,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        stack_trace: Option<Vec<String>>,
-    },
-    ProcessEnumeration {
-        function_name: String,
-        parameters: serde_json::Value,
-    },
-    MemoryScan {
-        status: String,
-        result: String,
-    },
-    VmpTrace {
-        message: String,
-        details: serde_json::Value,
-    },
-    FileOperation {
-        path: String,
-        operation: String,
-        details: String,
-    },
-    Error {
-        source: String,
-        message: String,
-    },
-    VmpSectionFound {
-        module_path: String,
-        section_name: String,
-    },
-    StaticAnalysis {
-        finding: String,
-        details: String,
-    },
-    StringDump {
-        address: usize,
-        value: String,
-        encoding: String,
-    },
-    UnpackerActivity {
-        source_address: usize,
-        finding: String,
-        details: String,
-    },
-    SectionList {
-        sections: Vec<SectionInfo>,
-    },
-    SectionDump {
-        name: String,
-        data: Vec<u8>,
-    },
-    EntropyResult {
-        name: String,
-        entropy: Vec<f32>,
-    },
-    ModuleDump {
-        module_name: String,
-        data: Vec<u8>,
-    },
-}
-
-/// Holds information about a single PE section.
-#[derive(Serialize, Debug, Clone)]
-pub struct SectionInfo {
-    pub name: String,
-    pub virtual_address: usize,
-    pub virtual_size: usize,
-    pub characteristics: u32,
-}
-
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct PeHeaderInfo {
     pub machine: String,
@@ -190,4 +86,3 @@ pub struct SectionDetail {
     pub characteristics: String,
     pub entropy: f32,
 }
-

--- a/client/src/scanner.rs
+++ b/client/src/scanner.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code, unused_variables)]
-use crate::config::LogLevel;
-use crate::logging::LogEvent;
+use shared::logging::{LogLevel, LogEvent};
 use crate::{log_event, ReentrancyGuard};
 use patternscan::scan;
 use std::ffi::OsString;

--- a/client/src/string_dumper.rs
+++ b/client/src/string_dumper.rs
@@ -2,8 +2,7 @@
 // for strings, which can reveal interesting information about a program's
 // behavior, such as hidden commands, URLs, or configuration data.
 // It will run in a background thread.
-use crate::config::LogLevel;
-use crate::logging::LogEvent;
+use shared::logging::{LogLevel, LogEvent};
 use crate::{log_event, ReentrancyGuard};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};

--- a/client/src/vmp_dumper.rs
+++ b/client/src/vmp_dumper.rs
@@ -1,8 +1,7 @@
 // monitor_lib/src/vmp_dumper.rs
 #![allow(dead_code, unused_variables)]
 
-use crate::config::LogLevel;
-use crate::logging::LogEvent;
+use shared::logging::{LogLevel, LogEvent};
 use crate::{log_event, SUSPICION_SCORE};
 use chrono::{DateTime, Utc};
 use std::sync::atomic::Ordering;

--- a/loader/src/gui/launcher.rs
+++ b/loader/src/gui/launcher.rs
@@ -6,6 +6,9 @@ use crate::app::state::AppState;
 use crate::core::analysis;
 
 pub fn render_launcher_window(ctx: &egui::Context, state: &mut AppState) {
+    let mut auto_inject_clicked = false;
+    let mut auto_inject_enabled = state.auto_inject_enabled.load(Ordering::SeqCst);
+
     egui::Window::new("Launcher & Controls")
         .open(&mut state.windows.launcher_window_open)
         .vscroll(true)
@@ -65,89 +68,20 @@ pub fn render_launcher_window(ctx: &egui::Context, state: &mut AppState) {
                 if ui.add_enabled(state.is_process_running.load(Ordering::SeqCst), egui::Button::new("Terminate Process")).clicked() {
                     analysis::terminate_process(state.process_handle.clone());
                 }
+
+                if ui.checkbox(&mut auto_inject_enabled, "Auto-Inject").clicked() {
+                    auto_inject_clicked = true;
+                }
             });
 
             ui.separator();
             ui.label(format!("Status: {}", *state.injection_status.lock().unwrap()));
-            ui.separator();
-
-            ui.heading("Hooking Controls");
-            ui.collapsing("General Settings", |ui| {
-                ui.checkbox(&mut state.monitor_config.api_hooks_enabled, "Enable General API Hooks");
-                ui.checkbox(&mut state.monitor_config.iat_scan_enabled, "IAT Hook Scanning");
-                ui.checkbox(&mut state.monitor_config.string_dump_enabled, "Live String Dumping");
-                ui.checkbox(&mut state.monitor_config.vmp_dump_enabled, "VMP Section Scanning");
-                ui.checkbox(&mut state.monitor_config.manual_map_scan_enabled, "Manual Map Detection");
-                ui.checkbox(&mut state.monitor_config.network_hooks_enabled, "Network Function Hooks (WinINet, WS2_32)");
-                ui.checkbox(&mut state.monitor_config.crypto_hooks_enabled, "Cryptography Hooks (CryptoAPI)");
-                ui.checkbox(&mut state.monitor_config.registry_hooks_enabled, "Registry Hooks");
-                ui.checkbox(&mut state.monitor_config.log_network_data, "Log Full Network Data Payloads");
-            });
-            ui.collapsing("Individual Hook Controls", |ui| {
-                ui.checkbox(&mut state.monitor_config.hook_open_process, "OpenProcess");
-                ui.checkbox(&mut state.monitor_config.hook_write_process_memory, "WriteProcessMemory");
-                ui.checkbox(&mut state.monitor_config.hook_virtual_alloc_ex, "VirtualAllocEx");
-                ui.checkbox(&mut state.monitor_config.hook_create_file_w, "CreateFileW");
-                ui.checkbox(&mut state.monitor_config.hook_write_file, "WriteFile");
-                ui.checkbox(&mut state.monitor_config.hook_http_send_request_w, "HttpSendRequestW");
-                ui.checkbox(&mut state.monitor_config.hook_terminate_process, "TerminateProcess");
-                ui.checkbox(&mut state.monitor_config.hook_nt_terminate_process, "NtTerminateProcess");
-                ui.checkbox(&mut state.monitor_config.hook_message_box_w, "MessageBoxW");
-                ui.checkbox(&mut state.monitor_config.hook_create_process_w, "CreateProcessW");
-                ui.checkbox(&mut state.monitor_config.hook_load_library_w, "LoadLibraryW");
-                ui.checkbox(&mut state.monitor_config.hook_load_library_ex_w, "LoadLibraryExW");
-                ui.checkbox(&mut state.monitor_config.hook_connect, "connect");
-                ui.checkbox(&mut state.monitor_config.hook_reg_create_key_ex_w, "RegCreateKeyExW");
-                ui.checkbox(&mut state.monitor_config.hook_reg_set_value_ex_w, "RegSetValueExW");
-                ui.checkbox(&mut state.monitor_config.hook_reg_delete_key_w, "RegDeleteKeyW");
-                ui.checkbox(&mut state.monitor_config.hook_reg_open_key_ex_w, "RegOpenKeyExW");
-                ui.checkbox(&mut state.monitor_config.hook_reg_query_value_ex_w, "RegQueryValueExW");
-                ui.checkbox(&mut state.monitor_config.hook_reg_enum_key_ex_w, "RegEnumKeyExW");
-                ui.checkbox(&mut state.monitor_config.hook_reg_enum_value_w, "RegEnumValueW");
-                ui.checkbox(&mut state.monitor_config.hook_delete_file_w, "DeleteFileW");
-                ui.checkbox(&mut state.monitor_config.hook_create_remote_thread, "CreateRemoteThread");
-                ui.checkbox(&mut state.monitor_config.hook_get_addr_info_w, "GetAddrInfoW");
-                ui.checkbox(&mut state.monitor_config.hook_is_debugger_present, "IsDebuggerPresent");
-                ui.checkbox(&mut state.monitor_config.hook_check_remote_debugger_present, "CheckRemoteDebuggerPresent");
-                ui.checkbox(&mut state.monitor_config.hook_nt_query_information_process, "NtQueryInformationProcess");
-                ui.checkbox(&mut state.monitor_config.hook_create_toolhelp32_snapshot, "CreateToolhelp32Snapshot");
-                ui.checkbox(&mut state.monitor_config.hook_process32_first_w, "Process32FirstW");
-                ui.checkbox(&mut state.monitor_config.hook_process32_next_w, "Process32NextW");
-                ui.checkbox(&mut state.monitor_config.hook_exit_process, "ExitProcess");
-                ui.checkbox(&mut state.monitor_config.hook_get_tick_count, "GetTickCount");
-                ui.checkbox(&mut state.monitor_config.hook_query_performance_counter, "QueryPerformanceCounter");
-                ui.checkbox(&mut state.monitor_config.hook_output_debug_string_a, "OutputDebugStringA");
-                ui.checkbox(&mut state.monitor_config.hook_add_vectored_exception_handler, "AddVectoredExceptionHandler");
-                ui.checkbox(&mut state.monitor_config.hook_create_thread, "CreateThread");
-                ui.checkbox(&mut state.monitor_config.hook_free_library, "FreeLibrary");
-                ui.checkbox(&mut state.monitor_config.hook_crypt_encrypt, "CryptEncrypt");
-                ui.checkbox(&mut state.monitor_config.hook_crypt_decrypt, "CryptDecrypt");
-                ui.checkbox(&mut state.monitor_config.hook_wsasend, "WSASend");
-                ui.checkbox(&mut state.monitor_config.hook_wsarecv, "WSARecv");
-                ui.checkbox(&mut state.monitor_config.hook_send, "send");
-                ui.checkbox(&mut state.monitor_config.hook_recv, "recv");
-                ui.checkbox(&mut state.monitor_config.hook_internet_open_w, "InternetOpenW");
-                ui.checkbox(&mut state.monitor_config.hook_internet_connect_w, "InternetConnectW");
-                ui.checkbox(&mut state.monitor_config.hook_http_open_request_w, "HttpOpenRequestW");
-                ui.checkbox(&mut state.monitor_config.hook_internet_read_file, "InternetReadFile");
-                ui.checkbox(&mut state.monitor_config.hook_dns_query_a, "DnsQuery_A");
-                ui.checkbox(&mut state.monitor_config.hook_dns_query_w, "DnsQuery_W");
-                ui.checkbox(&mut state.monitor_config.hook_cert_verify_certificate_chain_policy, "CertVerifyCertificateChainPolicy");
-                ui.checkbox(&mut state.monitor_config.hook_crypt_hash_data, "CryptHashData");
-                ui.checkbox(&mut state.monitor_config.hook_copy_file_w, "CopyFileW");
-                ui.checkbox(&mut state.monitor_config.hook_move_file_w, "MoveFileW");
-                ui.checkbox(&mut state.monitor_config.hook_get_temp_path_w, "GetTempPathW");
-                ui.checkbox(&mut state.monitor_config.hook_get_temp_file_name_w, "GetTempFileNameW");
-                ui.checkbox(&mut state.monitor_config.hook_find_first_file_w, "FindFirstFileW");
-                ui.checkbox(&mut state.monitor_config.hook_find_next_file_w, "FindNextFileW");
-                ui.checkbox(&mut state.monitor_config.hook_nt_create_thread_ex, "NtCreateThreadEx");
-                ui.checkbox(&mut state.monitor_config.hook_queue_user_apc, "QueueUserAPC");
-                ui.checkbox(&mut state.monitor_config.hook_set_thread_context, "SetThreadContext");
-                ui.checkbox(&mut state.monitor_config.hook_win_exec, "WinExec");
-                ui.checkbox(&mut state.monitor_config.hook_system, "system");
-                ui.checkbox(&mut state.monitor_config.hook_shell_execute_w, "ShellExecuteW");
-                ui.checkbox(&mut state.monitor_config.hook_shell_execute_ex_w, "ShellExecuteExW");
-                ui.checkbox(&mut state.monitor_config.hook_create_process_a, "CreateProcessA");
-            });
         });
+
+    if auto_inject_clicked {
+        state.auto_inject_enabled.store(auto_inject_enabled, Ordering::SeqCst);
+        if auto_inject_enabled {
+            analysis::start_auto_inject_thread(state);
+        }
+    }
 }

--- a/loader/src/gui/live_logs.rs
+++ b/loader/src/gui/live_logs.rs
@@ -1,6 +1,7 @@
 use eframe::egui;
 
-use crate::app::state::{AppState, LogLevel};
+use crate::app::state::AppState;
+use shared::logging::{LogEvent, LogLevel};
 
 pub fn render_log_window(ctx: &egui::Context, state: &mut AppState) {
     if !state.windows.log_window_open {
@@ -35,48 +36,63 @@ pub fn render_log_window(ctx: &egui::Context, state: &mut AppState) {
         });
 }
 
-fn format_log_event(event: &crate::app::state::LogEvent) -> String {
+fn format_log_event(event: &LogEvent) -> String {
     match event {
-        crate::app::state::LogEvent::Message(msg) => msg.clone(),
-        crate::app::state::LogEvent::Initialization { status } => status.clone(),
-        crate::app::state::LogEvent::Shutdown { status } => status.clone(),
-        crate::app::state::LogEvent::ApiHook {
+        LogEvent::Message(msg) => msg.clone(),
+        LogEvent::Initialization { status } => status.clone(),
+        LogEvent::Shutdown { status } => status.clone(),
+        LogEvent::ApiHook {
             function_name,
             parameters,
             ..
         } => format!("API Hook: {} | Params: {}", function_name, parameters),
-        crate::app::state::LogEvent::AntiDebugCheck {
+        LogEvent::AntiDebugCheck {
             function_name,
             parameters,
             ..
         } => format!("Anti-Debug: {} | Params: {}", function_name, parameters),
-        crate::app::state::LogEvent::ProcessEnumeration {
+        LogEvent::ProcessEnumeration {
             function_name,
             parameters,
         } => format!("Process Enum: {} | Params: {}", function_name, parameters),
-        crate::app::state::LogEvent::MemoryScan { status, result } => {
+        LogEvent::MemoryScan { status, result } => {
             format!("Scan: {} -> {}", status, result)
         }
-        crate::app::state::LogEvent::Error { source, message } => {
+        LogEvent::Error { source, message } => {
             format!("ERROR [{}]: {}", source, message)
         }
-        crate::app::state::LogEvent::FileOperation {
+        LogEvent::FileOperation {
             path,
             operation,
             details,
         } => format!("File Op: {} on {} | Details: {}", operation, path, details),
-        crate::app::state::LogEvent::VmpSectionFound {
+        LogEvent::VmpSectionFound {
             module_path,
             section_name,
         } => format!("VMP Section: {} in {}", section_name, module_path),
-        crate::app::state::LogEvent::SectionList { sections } => {
+        LogEvent::SectionList { sections } => {
             format!("Received section list with {} entries.", sections.len())
         }
-        crate::app::state::LogEvent::SectionDump { name, data } => {
+        LogEvent::SectionDump { name, data } => {
             format!("Dumped section '{}' ({} bytes).", name, data.len())
         }
-        crate::app::state::LogEvent::EntropyResult { name, .. } => {
+        LogEvent::EntropyResult { name, .. } => {
             format!("Calculated entropy for section '{}'.", name)
+        }
+        LogEvent::ModuleDump { module_name, data } => {
+            format!("Dumped module '{}' ({} bytes).", module_name, data.len())
+        }
+        LogEvent::VmpTrace { message, details } => {
+            format!("VMP Trace: {} | Details: {}", message, details)
+        }
+        LogEvent::StaticAnalysis { finding, details } => {
+            format!("Static Analysis: {} | Details: {}", finding, details)
+        }
+        LogEvent::StringDump { address, value, .. } => {
+            format!("String at {:#x}: {}", address, value)
+        }
+        LogEvent::UnpackerActivity { source_address, finding, details } => {
+            format!("Unpacker activity at {:#x}: {} | Details: {}", source_address, finding, details)
         }
     }
 }

--- a/shared/Cargo.toml
+++ b/shared/Cargo.toml
@@ -5,3 +5,5 @@ edition = "2021"
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
+chrono = { version = "0.4", features = ["serde"] }

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -1,3 +1,5 @@
+pub mod logging;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -21,6 +23,8 @@ pub struct MonitorConfig {
     pub crypto_hooks_enabled: bool,
     pub log_network_data: bool,
     pub suspicion_threshold: u32,
+    pub stack_trace_on_error: bool,
+    pub stack_trace_frame_limit: usize,
     // Add a boolean for each hook
     pub hook_open_process: bool,
     pub hook_write_process_memory: bool,
@@ -101,6 +105,8 @@ impl Default for MonitorConfig {
             crypto_hooks_enabled: true,
             log_network_data: false,
             suspicion_threshold: 10,
+            stack_trace_on_error: true,
+            stack_trace_frame_limit: 16,
             // Set all hooks to true by default
             hook_open_process: true,
             hook_write_process_memory: true,

--- a/shared/src/logging.rs
+++ b/shared/src/logging.rs
@@ -1,0 +1,105 @@
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+// This enum is now the single source of truth for log levels.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum LogLevel {
+    Fatal = 0,
+    Error = 1,
+    Success = 2,
+    Warn = 3,
+    Info = 4,
+    Debug = 5,
+    Trace = 6,
+}
+
+// This struct is now the single source of truth for PE section info.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct SectionInfo {
+    pub name: String,
+    pub virtual_address: usize,
+    pub virtual_size: usize,
+    pub characteristics: u32,
+}
+
+// This enum is now the single source of truth for all possible log events.
+// It combines the variants from both the old loader and client definitions.
+#[derive(Serialize, Deserialize, Debug, Clone)]
+#[serde(tag = "event_type", content = "details")]
+pub enum LogEvent {
+    // Variants from both
+    Initialization { status: String },
+    Shutdown { status: String },
+    Error { source: String, message: String },
+    FileOperation { path: String, operation: String, details: String },
+    VmpSectionFound { module_path: String, section_name: String },
+    SectionList { sections: Vec<SectionInfo> },
+    SectionDump { name: String, data: Vec<u8> },
+    EntropyResult { name: String, entropy: Vec<f32> },
+    ModuleDump { module_name: String, data: Vec<u8> },
+    ApiHook {
+        function_name: String,
+        parameters: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stack_trace: Option<Vec<String>>,
+    },
+    AntiDebugCheck {
+        function_name: String,
+        parameters: serde_json::Value,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        stack_trace: Option<Vec<String>>,
+    },
+    ProcessEnumeration { function_name: String, parameters: serde_json::Value },
+    MemoryScan { status: String, result: String },
+    // Client-specific variants
+    VmpTrace { message: String, details: serde_json::Value },
+    StaticAnalysis { finding: String, details: String },
+    StringDump { address: usize, value: String, encoding: String },
+    UnpackerActivity { source_address: usize, finding: String, details: String },
+    // Loader-specific variant
+    Message(String),
+}
+
+// Custom PartialEq to handle JSON value comparison
+impl PartialEq for LogEvent {
+    fn eq(&self, other: &Self) -> bool {
+        serde_json::to_string(self).unwrap_or_default() == serde_json::to_string(other).unwrap_or_default()
+    }
+}
+
+// This struct is now the single source of truth for a log entry.
+#[derive(Serialize, Deserialize, Debug)]
+pub struct LogEntry {
+    #[serde(with = "chrono::serde::ts_seconds")]
+    pub timestamp: DateTime<Utc>,
+    pub level: LogLevel,
+    pub process_id: u32,
+    pub thread_id: u32,
+    pub suspicion_score: usize,
+    #[serde(flatten)]
+    pub event: LogEvent,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stack_trace: Option<Vec<String>>,
+}
+
+// Custom PartialEq for deduplication logic in the loader
+impl PartialEq for LogEntry {
+    fn eq(&self, other: &Self) -> bool {
+        self.level == other.level && self.event == other.event
+    }
+}
+
+// Helper function for creating log entries in the loader
+impl LogEntry {
+    pub fn new_from_loader(level: LogLevel, event: LogEvent) -> Self {
+        Self {
+            timestamp: Utc::now(),
+            level,
+            process_id: 0, // Loader doesn't know this
+            thread_id: 0, // Loader doesn't know this
+            suspicion_score: 0,
+            event,
+            stack_trace: None,
+        }
+    }
+}


### PR DESCRIPTION
This commit addresses several issues and adds a new feature:

- **Fix Logging and Entropy Viewer:** Centralized the `LogEntry`, `LogEvent`, and `LogLevel` definitions into a new `shared` crate to resolve serialization mismatches between the `loader` and `client`. This fixes the broken logging and the entropy viewer, which depends on it.
- **Fix DLL Name:** The loader is now configured to look for `client.dll` instead of the old `monitor_lib.dll`.
- **Remove Duplicate UI:** Removed the redundant "Hooking Controls" section from the main launcher window to eliminate UI duplication.
- **Add Auto-Inject Feature:** Implemented an "Auto-Inject" checkbox in the loader UI. When enabled, it spawns a background thread to automatically find the target process and inject the `client.dll` as soon as the process becomes available.