### PR TITLE
Fix pipe communication and preset UI logic

### DIFF
--- a/loader/src/gui/launcher.rs
+++ b/loader/src/gui/launcher.rs
@@ -35,20 +35,19 @@ pub fn render_launcher_tab(_ctx: &egui::Context, ui: &mut Ui, state: &mut AppSta
                 // Preset selection
                 ui.horizontal(|ui| {
                     ui.label("Monitoring Preset:");
+                    let mut preset_changed = false;
                     let selected_preset_text = format!("{:?}", state.selected_preset);
                     egui::ComboBox::from_id_source("preset_selector")
                         .selected_text(selected_preset_text)
                         .show_ui(ui, |ui| {
-                            if ui.selectable_value(&mut state.selected_preset, Preset::Stealth, "Stealth").changed() {
-                                state.monitor_config = MonitorConfig::from_preset(Preset::Stealth);
-                            }
-                            if ui.selectable_value(&mut state.selected_preset, Preset::Balanced, "Balanced").changed() {
-                                state.monitor_config = MonitorConfig::from_preset(Preset::Balanced);
-                            }
-                            if ui.selectable_value(&mut state.selected_preset, Preset::Aggressive, "Aggressive").changed() {
-                                state.monitor_config = MonitorConfig::from_preset(Preset::Aggressive);
-                            }
+                            preset_changed |= ui.selectable_value(&mut state.selected_preset, Preset::Stealth, "Stealth").changed();
+                            preset_changed |= ui.selectable_value(&mut state.selected_preset, Preset::Balanced, "Balanced").changed();
+                            preset_changed |= ui.selectable_value(&mut state.selected_preset, Preset::Aggressive, "Aggressive").changed();
                         });
+
+                    if preset_changed {
+                        state.monitor_config = MonitorConfig::from_preset(state.selected_preset);
+                    }
                 });
 
                 ui.separator();


### PR DESCRIPTION
This commit addresses two critical bugs:

1.  **Pipe Communication Failure:** The client DLL was failing to initialize because it could not reliably receive the configuration from the loader. The existing named pipe communication used a fixed-size buffer, leading to silent failures if the config was too large.

    This is fixed by implementing a more robust, size-prepended protocol:
    - The loader now sends the size of the configuration (as a u32) before sending the configuration data itself.
    - The client reads this size first, then reads the exact number of bytes for the configuration. This ensures the entire configuration is always transferred correctly, allowing the client to initialize properly.

2.  **Preset GUI Bug:** The preset selection in the UI did not correctly update the `monitor_config` state, causing the checkboxes in the hooking tab to remain unchanged.

    This is fixed by refactoring the UI logic to update the `monitor_config` based on the selected preset *after* the ComboBox selection has been made, ensuring the UI state is always consistent.