### PR TITLE
refactor(ipc): Standardize on newline-delimited JSON protocol

### DIFF
--- a/loader/src/core/communication.rs
+++ b/loader/src/core/communication.rs
@@ -11,12 +11,13 @@ use windows_sys::Win32::{
     },
 };
 
-use shared::MonitorConfig;
+use shared::{Command, MonitorConfig};
 use widestring::U16CString;
 
 pub fn start_pipe_log_listener(pipe_handle: isize, logger: Sender<String>) {
     thread::spawn(move || {
         let mut buffer = [0u8; 4096];
+        let mut message_buffer = String::new();
         loop {
             let mut bytes_read = 0;
             let success = unsafe {
@@ -28,12 +29,21 @@ pub fn start_pipe_log_listener(pipe_handle: isize, logger: Sender<String>) {
                     std::ptr::null_mut(),
                 )
             } != 0;
+
             if success && bytes_read > 0 {
-                let message = String::from_utf8_lossy(&buffer[..bytes_read as usize]);
-                for line in message.lines().filter(|l| !l.trim().is_empty()) {
-                    let _ = logger.send(line.to_string());
+                let chunk = String::from_utf8_lossy(&buffer[..bytes_read as usize]);
+                message_buffer.push_str(&chunk);
+
+                // Process all complete messages (newline-delimited) in the buffer.
+                while let Some(newline_pos) = message_buffer.find('\n') {
+                    let message = message_buffer.drain(..=newline_pos).collect::<String>();
+                    let trimmed_message = message.trim();
+                    if !trimmed_message.is_empty() {
+                        let _ = logger.send(trimmed_message.to_string());
+                    }
                 }
             } else {
+                // Pipe was closed or an error occurred.
                 break;
             }
         }
@@ -62,7 +72,7 @@ pub fn connect_and_send_config(
                 0,
                 std::ptr::null(),
                 OPEN_EXISTING,
-                0, // Not using FILE_FLAG_OVERLAPPED for the initial connection
+                0,
                 0,
             )
         };
@@ -77,38 +87,48 @@ pub fn connect_and_send_config(
             return false;
         }
 
-        // Pipe is busy, wait and retry
-        *status_arc.lock().unwrap() = format!("Pipe is busy, retrying... ({}/{})", i + 1, MAX_RETRIES);
+        *status_arc.lock().unwrap() =
+            format!("Pipe is busy, retrying... ({}/{})", i + 1, MAX_RETRIES);
         thread::sleep(Duration::from_millis(RETRY_DELAY_MS));
     }
 
     if pipe_handle != INVALID_HANDLE_VALUE {
         let mut pipe_handle_guard = pipe_handle_arc.lock().unwrap();
         *pipe_handle_guard = Some(pipe_handle);
-        drop(pipe_handle_guard); // Release lock before potentially long operations
+        drop(pipe_handle_guard);
 
-        let config_json = serde_json::to_string(config).unwrap();
-        let config_bytes = config_json.as_bytes();
-        let config_len = config_bytes.len() as u32;
-
-        // Prepend the size of the JSON data to the message.
-        let mut data_to_send = Vec::with_capacity(4 + config_bytes.len());
-        data_to_send.extend_from_slice(&config_len.to_ne_bytes());
-        data_to_send.extend_from_slice(config_bytes);
+        // --- Standardized Communication ---
+        // Wrap the config in an `UpdateConfig` command and send it as a newline-terminated JSON string.
+        let command = Command::UpdateConfig(*config);
+        let command_json = match serde_json::to_string(&command) {
+            Ok(json) => json,
+            Err(e) => {
+                *status_arc.lock().unwrap() = format!("Failed to serialize config: {}", e);
+                return false;
+            }
+        };
+        let command_to_send = format!("{}\n", command_json);
+        let bytes_to_send = command_to_send.as_bytes();
 
         let mut bytes_written = 0;
         let success = unsafe {
             WriteFile(
                 pipe_handle,
-                data_to_send.as_ptr() as *const _,
-                data_to_send.len() as u32,
+                bytes_to_send.as_ptr(),
+                bytes_to_send.len() as u32,
                 &mut bytes_written,
                 std::ptr::null_mut(),
             )
         };
-        if success == 0 || bytes_written as usize != data_to_send.len() {
+
+        if success == 0 || bytes_written as usize != bytes_to_send.len() {
             let err = unsafe { GetLastError() };
-            *status_arc.lock().unwrap() = format!("Failed to write config to pipe (wrote {}/{} bytes): {}", bytes_written, data_to_send.len(), err);
+            *status_arc.lock().unwrap() = format!(
+                "Failed to write config to pipe (wrote {}/{} bytes): {}",
+                bytes_written,
+                bytes_to_send.len(),
+                err
+            );
             return false;
         }
 


### PR DESCRIPTION
This commit refactors the inter-process communication between the `loader` and the `client` DLL to use a single, robust protocol for all messages.

Previously, the initial `MonitorConfig` was sent using a fragile length-prefixing scheme, while subsequent commands were sent as newline-delimited JSON. This inconsistency was the likely cause of configuration failures, preventing hooks from being installed correctly.

The new implementation standardizes on newline-delimited JSON for all communication:
- The initial `MonitorConfig` is now wrapped in a `Command::UpdateConfig` enum.
- All commands are serialized to a JSON string and terminated with a newline character (`\n`).
- The client-side initialization and command-handling logic have been unified to use a single, line-buffered reading mechanism, making the protocol resilient to partial reads from the named pipe.

This change eliminates the dual-protocol complexity and creates a more reliable and maintainable communication channel.